### PR TITLE
feat : enabling copy & paste single node

### DIFF
--- a/components/workflow/workflowCanvas.tsx
+++ b/components/workflow/workflowCanvas.tsx
@@ -115,9 +115,7 @@ export default function Workflow() {
   const [openDrawer, setDrawerOpen] = useState(false);
   const [projectName, setProjectName] = useState('Untitled');
   const [corsSettings, setCorsSettings] = useState<CorsOptionsCustom>({});
-
   const isMobile = useIsMobile();
-
   // const [openFeatureModal, setFeatureModal] = useState<boolean>(true);
   // const [features, setFeatures] = useState<string[]>([]);
   useEffect(() => {
@@ -279,6 +277,33 @@ export default function Workflow() {
   //   setFeatures(data);
   // };
 
+  // copy & past nodes
+  const handleCopyPasteNode = () => {
+    const selectedNodes = nodes.filter((node) => node.selected);
+    if (selectedNodes.length === 0) return;
+
+    const selectedNode = selectedNodes[0];
+
+    const pasteNode = () => {
+      const newNode: NodeProps = {
+        id: getNodeId(),
+        data: {
+          name: selectedNode.data.name,
+          props: selectedNode.data.props,
+          relations: [],
+        },
+        position: {
+          x: (Math.random() - 0.5) * 400,
+          y: (Math.random() - 0.5) * 400,
+        },
+        type: 'card',
+      };
+      setNodes((nds) => nds.concat(newNode));
+    };
+
+    pasteNode();
+  };
+
   return (
     <>
       <div style={{ width: '100vw', height: '100dvh' }}>
@@ -299,6 +324,7 @@ export default function Workflow() {
           onInit={(e) => setRfInstance(e as unknown as ReactFlowInstance)}
           defaultEdgeOptions={defaultEdgeOptions}
           deleteKeyCode={['Backspace', 'Delete']}
+          onPaste={handleCopyPasteNode}
           // connectionLineComponent={CustomConnectionLine}
           connectionLineStyle={connectionLineStyle}
           connectionLineType={ConnectionLineType.Step}


### PR DESCRIPTION
## Description
Feature: Enable copy & paste for a single node

## Major Changes
1.Implemented handleCopyPasteNode function to support copying and pasting a node

2.If a node is currently selected, pressing Ctrl + V will paste a duplicate of that node

3.If no node is selected, the paste function is disabled to prevent unintended behavior

## Improvements / Suggestions
1.Currently supports only single-node copy; consider extending support to multiple nodes

2.Properties and names are copied only if the user explicitly saves them by clicking the ✓ (confirm) button

3.From a UX perspective, saving on Enter keypress would be more intuitive, as many users expect it from standard UI behavior — this could be a useful enhancement

4.I think using a Date as an id might not be very safe.
It's possible to get duplicate values if multiple nodes are created within the same millisecond.
Maybe consider using something more robust, like a UUID or a timestamp combined with a random string?
